### PR TITLE
Update golangci-lint version to v1.17.1

### DIFF
--- a/golang/Dockerfile
+++ b/golang/Dockerfile
@@ -14,7 +14,7 @@ RUN apk add --no-cache --virtual .build-deps bash gcc musl-dev openssl go; \
     cd /; \
     wget -O - -q \
 	    https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| \
-	    sh -s v1.13.2; \
+	    sh -s v1.17.1; \
 	golangci-lint --version;
 
 CMD ["go"]


### PR DESCRIPTION
The reason why we update this is because we encountered panic in golangci-lint v.1.13.2 when it run against IAM-Postgres-Phase-1 branch. However, the panic disappear after we update the golangci-lint version to v1.17.1