### PR TITLE
update openjdk base image to follow trivy's recommendation

### DIFF
--- a/openjdk/HotSpot/11/Dockerfile.jdk.alpine
+++ b/openjdk/HotSpot/11/Dockerfile.jdk.alpine
@@ -1,4 +1,4 @@
-FROM accelbyte/alpine:3.9
+FROM accelbyte/alpine:<alpine_version>
 LABEL maintainer "operations@accelbyte.net"
 
 ENV OPENJDK="OpenJDK11U-jdk_x64_linux_hotspot_11.0.2_9.tar.gz"

--- a/openjdk/HotSpot/11/Dockerfile.jre.alpine
+++ b/openjdk/HotSpot/11/Dockerfile.jre.alpine
@@ -1,4 +1,4 @@
-FROM accelbyte/alpine:3.9
+FROM accelbyte/alpine:<alpine_version>
 LABEL maintainer "operations@accelbyte.net"
 
 ENV OPENJDK="OpenJDK11U-jre_x64_linux_hotspot_11.0.2_9.tar.gz"

--- a/openjdk/HotSpot/8/Dockerfile.jdk.alpine
+++ b/openjdk/HotSpot/8/Dockerfile.jdk.alpine
@@ -1,4 +1,4 @@
-FROM accelbyte/alpine:3.9
+FROM accelbyte/alpine:<alpine_version>
 LABEL maintainer "operations@accelbyte.net"
 
 ENV OPENJDK="OpenJDK8U-jdk_x64_linux_hotspot_8u232b09.tar.gz"

--- a/openjdk/HotSpot/8/Dockerfile.jre.alpine
+++ b/openjdk/HotSpot/8/Dockerfile.jre.alpine
@@ -1,4 +1,4 @@
-FROM accelbyte/alpine:3.9
+FROM accelbyte/alpine:<alpine_version>
 LABEL maintainer "operations@accelbyte.net"
 
 ENV OPENJDK="OpenJDK8U-jre_x64_linux_hotspot_8u232b09.tar.gz"

--- a/openjdk/OpenJ9/11/Dockerfile.jdk.alpine
+++ b/openjdk/OpenJ9/11/Dockerfile.jdk.alpine
@@ -1,4 +1,4 @@
-FROM accelbyte/alpine:3.9
+FROM accelbyte/alpine:<alpine_version>
 LABEL maintainer "operations@accelbyte.net"
 
 ENV OPENJDK="OpenJDK11U-jdk_x64_linux_openj9_11.0.2_9_openj9-0.12.1_openj9-0.12.1.tar.gz"

--- a/openjdk/OpenJ9/11/Dockerfile.jre.alpine
+++ b/openjdk/OpenJ9/11/Dockerfile.jre.alpine
@@ -1,4 +1,4 @@
-FROM accelbyte/alpine:3.9
+FROM accelbyte/alpine:<alpine_version>
 LABEL maintainer "operations@accelbyte.net"
 
 ENV OPENJDK="OpenJDK11U-jre_x64_linux_openj9_11.0.2_9_openj9-0.12.1_openj9-0.12.1.tar.gz"

--- a/openjdk/OpenJ9/8/Dockerfile.jdk.alpine
+++ b/openjdk/OpenJ9/8/Dockerfile.jdk.alpine
@@ -1,4 +1,4 @@
-FROM accelbyte/alpine:3.9
+FROM accelbyte/alpine:<alpine_version>
 LABEL maintainer "operations@accelbyte.net"
 
 ENV OPENJDK="OpenJDK8U-jdk_x64_linux_openj9_8u232b09_openj9-0.17.0.tar.gz"

--- a/openjdk/OpenJ9/8/Dockerfile.jre.alpine
+++ b/openjdk/OpenJ9/8/Dockerfile.jre.alpine
@@ -1,4 +1,4 @@
-FROM accelbyte/alpine:3.9
+FROM accelbyte/alpine:<alpine_version>
 LABEL maintainer "operations@accelbyte.net"
 
 ENV OPENJDK="OpenJDK8U-jre_x64_linux_openj9_linuxXL_8u232b09_openj9-0.17.0.tar.gz"

--- a/openjdk/build.sh
+++ b/openjdk/build.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+function usage() {
+cat << EOF
+Execute this script under the same directory
+  Example :
+    ./build.sh -j [hotspot/openj9] -o [jdk/jre (Kit option)] -v [8/11 (Java version)] -a [3.9 (alpine base image version from Accelbyte's docker hub)]
+EOF
+  exit 0
+}
+
+function check_args() {
+
+if [[ -z ${jvm_variant} ]] || [[ -z ${kit_option} ]] || [[ -z ${java_version} ]] || [[ -z ${alpine_version} ]]; then
+  echo "This script needs complete argument. Please use -h flag to see usage."
+  usage
+  exit 1
+fi
+
+if [[ "${kit_option}" != "jdk" && "${kit_option}" != "jre" ]]; then
+  echo "The kit option is either jdk or jre"
+  echo "Please use -h flag to see usage."
+  exit 1
+fi
+
+if [[ ${java_version} != "8" && ${java_version} != "11" ]] ; then
+  echo "The supported java version is 8 or 11"
+  echo "Please use -h flag to see usage."
+  exit 1
+fi
+
+}
+
+function configure_dockerfile() {
+  
+  if [[ ${jvm_variant} == "openj9" ]]; then
+    dockerfile_path="$PWD/OpenJ9/${java_version}/Dockerfile.${kit_option}.alpine"
+  elif [[ ${jvm_variant} == "hotspot" ]]; then
+    dockerfile_path="$PWD/HotSpot/${java_version}/Dockerfile.${kit_option}.alpine"
+  else
+    echo "we don't support that variant. Please use either openj9 or hotspot"
+    echo "Please check usage with -h"
+    exit 1
+  fi
+
+  sed -i "s#<alpine_version>#${alpine_version}#g" ${dockerfile_path}
+}
+
+function main() {
+  while getopts j:o:v:a:h option
+  do
+    case "${option}"
+      in
+      j) jvm_variant=${OPTARG};;
+      o) kit_option=${OPTARG};;
+      v) java_version=${OPTARG};;
+      a) alpine_version=${OPTARG};;
+      h) usage;;
+    esac
+  done
+  check_args
+  configure_dockerfile
+}
+
+main "$@"


### PR DESCRIPTION
- Change base image version to placeholder to make it easier to replace with sed.
- Create script for sed-ing openjdk's dockerfile